### PR TITLE
Add documentation for Envisalink alarm_arm_night service

### DIFF
--- a/source/_components/envisalink.markdown
+++ b/source/_components/envisalink.markdown
@@ -139,6 +139,7 @@ The following services are supported by Envisalink and can be used to script or 
 - **alarm_disarm**: Disarms the alarm with the user code provided, or the code specified in the configuration.
 - **alarm_arm_home**: Arms the alarm in home mode.
 - **alarm_arm_away**: Arms the alarm in standard away mode.
+- **alarm_arm_night**: Arms the alarm in night mode.
 - **alarm_trigger**: Trigger an alarm on the Envisalink connected alarm system. For example, a newer zwave/zigbee sensor can now be integrated into a legacy alarm system using a Home Assistant automation.
 - **envisalink_alarm_keypress**: Sends a string of up to 6 characters to the alarm. *DSC alarms only*
 - **invoke_custom_function**: Invokes a custom PGM function. *DSC alarms only*


### PR DESCRIPTION
**Description:**
Add documentation for Envisalink support for alarm control panel service alarm_arm_night

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#27087

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
